### PR TITLE
Fix for files in other directories

### DIFF
--- a/src/shared/AsyncZip.cpp
+++ b/src/shared/AsyncZip.cpp
@@ -307,7 +307,7 @@ namespace Corona
 		std::string fileName = archive->GetStr();
 		std::string archivePath	= LuaReader::GetPathForFileBaseDir(L,srcPath->GetData(),fileName.c_str());
 		
-		LVector fileList;
+		LVector fileList, rawFileList;
 		LMap *fileNames	= static_cast<LMap*>(paramsMap.GetData("srcFiles"));
 		
 		if (fileNames != NULL)
@@ -316,12 +316,14 @@ namespace Corona
 			for (int i = 0; i < keys.size(); i++)
 			{
 				LDataString *curFile = static_cast<LDataString*>(fileNames->GetData(keys[i]));
-				
+
 				const char *path =  LuaReader::GetPathForFileBaseDir(L,srcFilesPath->GetData(),curFile->GetStr().c_str());
+				CoronaLog("P %s, %s, %s", keys[i].c_str(), path, curFile->GetStr().c_str());
 				if (path != NULL)
 				{
 					std::string fullPath = path;
 					fileList.Push(fullPath);
+					rawFileList.Push(curFile->GetStr().c_str());
 				}
 				else
 				{
@@ -349,7 +351,7 @@ namespace Corona
 		
 		ZipTaskAddFileToZip *zipTask = new ZipTaskAddFileToZip( archivePath,
 															   password,
-															   fileList,
+															   fileList, rawFileList,
 															   coronaListener);
 		
 		AsyncTaskWithProxy *taskWithProxy = new AsyncTaskWithProxy(zipTask,this);

--- a/src/shared/AsyncZip.cpp
+++ b/src/shared/AsyncZip.cpp
@@ -318,7 +318,6 @@ namespace Corona
 				LDataString *curFile = static_cast<LDataString*>(fileNames->GetData(keys[i]));
 
 				const char *path =  LuaReader::GetPathForFileBaseDir(L,srcFilesPath->GetData(),curFile->GetStr().c_str());
-				CoronaLog("P %s, %s, %s", keys[i].c_str(), path, curFile->GetStr().c_str());
 				if (path != NULL)
 				{
 					std::string fullPath = path;

--- a/src/shared/ZipTask.cpp
+++ b/src/shared/ZipTask.cpp
@@ -429,11 +429,12 @@ namespace Corona
 //Add File
 ZipTaskAddFileToZip::ZipTaskAddFileToZip(	std::string pathSource,
 											std::string *password,
-											LVector fileList,
+											LVector fileList, LVector rawFileList,
 											CoronaLuaRef ref):
 	fPathSource(pathSource),
 	fPassword(password),
-	fFileList(fileList)
+	fFileList(fileList),
+	fRawFileList(rawFileList)
 	{
 		fRef = ref;
 	}
@@ -457,7 +458,8 @@ ZipTaskAddFileToZip::ZipTaskAddFileToZip(	std::string pathSource,
 		{
 			
 			std::string fileToAddName = fFileList.GetVal(i);
-			if (ZIP_OK != AddToZip(pathSource.c_str(), fileToAddName.c_str(), 0, password))
+			std::string rawFile = fRawFileList.GetVal(i);
+			if (ZIP_OK != AddToZip(pathSource.c_str(), fileToAddName.c_str(), rawFile.c_str(), 0, password))
 			{
 				fIsError = true;
 			}

--- a/src/shared/ZipTask.h
+++ b/src/shared/ZipTask.h
@@ -105,6 +105,7 @@ namespace Corona
 		ZipTaskAddFileToZip(std::string pathSource,
 							std::string *password,
 							LVector fileList,
+							LVector rawFileList,
 							CoronaLuaRef ref);
 		virtual ~ZipTaskAddFileToZip();
 		
@@ -116,7 +117,7 @@ namespace Corona
 	private:
 		std::string fPathSource;
 		std::string *fPassword;
-		LVector fFileList;
+		LVector fFileList, fRawFileList;
 		
 		//Output
 		std::vector<output_info> fOutputInfo;

--- a/src/shared/main_zip.h
+++ b/src/shared/main_zip.h
@@ -784,10 +784,9 @@ int ExtractAllFromZip(const char *zipFileName, int extractToDir, const char *dir
 	return ExtractFileFromZip(zipFileName,NULL,extractToDir,dirToExtractTo);
 }
 
-int AddToZip(const char *zipFileName, const char *fileToAdd, int includeFilePath, const char *password);
-int AddToZip(const char *zipFileName, const char *fileToAdd, int includeFilePath, const char *password)
+int AddToZip(const char *zipFileName, const char *fileToAdd, const char * rawFile, int includeFilePath, const char *password);
+int AddToZip(const char *zipFileName, const char *fileToAdd, const char * rawFile, int includeFilePath, const char *password)
 {
-	
     int overwriteZipFile=0;
     int opt_compress_level=Z_DEFAULT_COMPRESSION;
     char zipNameComplete[MAXFILENAME+16];
@@ -887,8 +886,13 @@ int AddToZip(const char *zipFileName, const char *fileToAdd, int includeFilePath
 	}
 	
 	/*should the zip file contain any path at all?*/
-	
-	if( includeFilePath == 0 )
+
+    if (rawFile)
+    {
+        savefilenameinzip = rawFile;
+    }
+
+	else if( includeFilePath == 0 )
 	{
 		const char *tmpptr;
 		const char *lastslash = 0;


### PR DESCRIPTION
A file with name `file.png` and another with `dir/file.png` will both get flattened to `file.png`. This is a side-effect of needing the path to get the file contents, and then aggressively stripping it later when the name is added to the zip's list: user-provided subdirectories get lost.

A simple fix is just to keep a parallel list without the full path and pass the two names, resolved and not, as inputs to the compress logic.