### PR TITLE
Add a param "includeFilePath" to compress() for compatibility.

### DIFF
--- a/src/shared/AsyncZip.cpp
+++ b/src/shared/AsyncZip.cpp
@@ -312,6 +312,12 @@ namespace Corona
 		
 		if (fileNames != NULL)
 		{
+			LDataBool *includeFilePath = static_cast<LDataBool*>(paramsMap.GetData("includeFilePath"));
+			bool bIncludeFilePath = false;
+			if (includeFilePath != NULL)
+			{
+				bIncludeFilePath = includeFilePath->GetBool();
+			}
 			std::vector<std::string> keys = fileNames->GetKeys();
 			for (int i = 0; i < keys.size(); i++)
 			{
@@ -322,7 +328,10 @@ namespace Corona
 				{
 					std::string fullPath = path;
 					fileList.Push(fullPath);
-					rawFileList.Push(curFile->GetStr().c_str());
+					if (bIncludeFilePath)
+					{
+						rawFileList.Push(curFile->GetStr().c_str());
+					}
 				}
 				else
 				{

--- a/src/shared/ZipTask.cpp
+++ b/src/shared/ZipTask.cpp
@@ -473,6 +473,7 @@ ZipTaskAddFileToZip::ZipTaskAddFileToZip(	std::string pathSource,
 		}
 		int vals = fFileList.GetCount();
 		
+		bool bIncludeFilePath = fRawFileList.GetCount() == vals;
 		for (int i = 0; i < vals && fIsError == false; i++)
 		{
 
@@ -486,8 +487,7 @@ ZipTaskAddFileToZip::ZipTaskAddFileToZip(	std::string pathSource,
 				continue;
 			}
 
-			std::string rawFile = fRawFileList.GetVal(i);
-			if (ZIP_OK != AddToZip(pathSource.c_str(), fileToAddName.c_str(), rawFile.c_str(), 0, password))
+			if (ZIP_OK != AddToZip(pathSource.c_str(), fileToAddName.c_str(), bIncludeFilePath ? fRawFileList.GetVal(i).c_str() : NULL, 0, password))
 			{
 				fIsError = true;
 			}


### PR DESCRIPTION
After [this PR](https://github.com/coronalabs/com.coronalabs-plugin.zip/pull/1), our apps are no longer working properly.
So we add a boolean param "includeFilePath" to compress(options). By default, plugin behaves like before [this PR](https://github.com/coronalabs/com.coronalabs-plugin.zip/pull/1).
```lua
zip.compress({
	zipFile = "test.zip",
	zipBaseDir = system.DocumentsDirectory,
	srcBaseDir = system.DocumentsDirectory,
	srcFiles = {"b.txt", "a/b.txt"},
	includeFilePath = true -- default is false
})
```