### PR TITLE
Fix directory traversal issue

### DIFF
--- a/src/shared/main_zip.h
+++ b/src/shared/main_zip.h
@@ -490,6 +490,12 @@ int do_extract_currentfile(    unzFile uf, const int* popt_extract_without_path,
         else
             write_filename = filename_withoutpath;
 
+        // Fix directory traversal issue.
+        // Modified from https://sources.debian.org/src/minizip/1.1-8/miniunz.c/#L369-L370 under the zlib license,
+        //   also delete the leading Windows-style dir sep.
+        while ((*write_filename) == '/' || (*write_filename) == '\\' || (*write_filename) == '.')
+            write_filename++;
+
         err = unzOpenCurrentFilePassword(uf,password);
         if (err!=UNZ_OK)
         {


### PR DESCRIPTION
Related to [coronalabs/corona#534](https://github.com/coronalabs/corona/issues/534).

This PR fixes CVE-2014-9485, which could not be detected by [intel/cve-bin-tool](https://github.com/intel/cve-bin-tool). The vulnerability was confirmed through manual testing after being informed by a partner.

## Reproduced

See debian bugreport [774321](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=774321), get the `traversal.zip` which contains:
```shell
Archive:  traversal.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
        4  01-01-2015 01:48   /tmp/moo
---------                     -------
        4                     1 file
```
Put `traversal.zip` into demo [solar2d_zip_traversal.zip](https://github.com/coronalabs/com.coronalabs-plugin.zip/files/11098963/solar2d_zip_traversal.zip) and test on:

- Mac Simulator, will create `moo` on `/tmp` directory.
- Windows Simulator, will create `moo` on `C:\tmp` directory.
- Android 13, nothing created on `/data/data/<applicationID>/app_data` and no `/tmp`(due to read-only fs or permission denied).

In addition, you can create a file by `echo Hello > ..\\\\Hello` and zip it into `Hello.zip` then run demo on windows:

```shell
Archive:  Hello.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
        6  03-29-2023 17:41   ..\\Hello
---------                     -------
        6                     1 file
```

Of course, these all require write permission.

## Patch

Based on my investigation, both [minizip](https://github.com/madler/zlib/tree/master/contrib/minizip) and old version of [minizip-ng](https://github.com/zlib-ng/minizip-ng) do not have this patch, instead, minizip-ng has updates on different route which can cause a lots of changes, and Debian has a [fix](https://sources.debian.org/src/minizip/1.1-8/miniunz.c/#L369-L370) but lacks a fix for Windows.

So this fix will remove leading characters `'/'`, `'\'`, and `'.'` to prevent issues with decompress outside the target directory as shown in the test case. Also delete `'\'` on *nix in order to uniform the presentation across platforms.

⚠️**However, this patch will result INCORRECTLY UNZIP folders or files named with those leading characters**

## Binaries

I can compile for Apple and Windows platforms but cannot determine the compile toolchain used for Android (unable to compile on NDK 16, 17, and 18 or changing stlport_static no longer supported by r18b to c++_static will encounter issues with creating subfolders, and modifying mymkdir did not solve this problem). Furthermore, binary files cannot be traced, so I believe it is more appropriate for @Shchvova to do the compile and upload.

If you need binaries or more changes, just let me know.