### PR TITLE
Compress/uncompress follow path option and default to relative paths

### DIFF
--- a/src/shared/main_zip.h
+++ b/src/shared/main_zip.h
@@ -893,12 +893,11 @@ int AddToZip(const char *zipFileName, const char *fileToAdd, const char * rawFil
 	
 	/*should the zip file contain any path at all?*/
 
-    if (rawFile)
+    if (rawFile && includeFilePath != 0)
     {
         savefilenameinzip = rawFile;
     }
-
-	else if( includeFilePath == 0 )
+	else
 	{
 		const char *tmpptr;
 		const char *lastslash = 0;


### PR DESCRIPTION
This PR is an addition to #1 and #4, and focuses on an issue where the former changes the use of relative paths, but the event `response` doesn't follow up.

Then there's "uncompress" the folder itself. minzip's extract supports decompressing the folder itself, i.e. creating the folder, which is necessary on some systems or filesystems. Some Unix-like systems don't allow writing directly to a file without creating the parent folder, which may have something to do with the fact that newer toolchains such as NDK r18b can't decompress subfolder contents when compiled, see https://github.com/coronalabs/com.coronalabs-plugin.zip/issues/3#issuecomment-1167240157 and https://github.com/coronalabs/com.coronalabs-plugin.zip/commit/7543eead524d4f2de354d72d0807cb0eb0211b47. Need confirmation from @ggcrunchy that it is feasible to merge the section.

This PR unresolved:

The `bool includeFilePath` is not read from the parameter because I can't find a safe way to read it yet, because map can't determine the Lua type. Also see #5, https://github.com/coronalabs/com.coronalabs-plugin.zip/issues/7#issuecomment-1818878062.

Another problem is that it is not possible to decompress the zip with the password and the test case does not pass. But just replace the `archive.zip` with a non-password one and it works fine. See #7, #8.